### PR TITLE
Add 'all' group to call sleepd API

### DIFF
--- a/files/sysbus/com.webos.service.activitymanager.perm.json
+++ b/files/sysbus/com.webos.service.activitymanager.perm.json
@@ -9,6 +9,7 @@
         "signals.all.subscribe",
         "system",
         "telephony",
-        "time.query"
+        "time.query",
+        "all"
     ]
 }


### PR DESCRIPTION
:Release Notes:
Add 'all' group to call sleepd API

:Detailed Notes:
Add 'all' group to call sleepd API

:Testing Performed:
unit-test : passed

:QA Notes:
Synced with develop branch#166

Change-Id: Iaa37d07b57b5d11686fd82ee23b096319486b69f